### PR TITLE
`connectable` property in `Async_VLC` class will not throw error if it isn't awaited

### DIFF
--- a/rest_vlc.py
+++ b/rest_vlc.py
@@ -579,7 +579,7 @@ else:
                         "Auth must be tuple or list of length 2 which is username and password"
                     )
                 self.auth = aiohttp.BasicAuth(*auth)
-            if not self.connectable:
+            if not asyncio.run(self.connectable):
                 raise Exception("VLC is not running or REST API is not enabled")
             self.full_screen = None
 


### PR DESCRIPTION
asyncio.run should fix this